### PR TITLE
RIS-9518 Minor changes for cloud deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 ./lua-scripts/*
-./docker-compose.yml
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN a2enmod cgi
 # Expose port 80 (http) and 5678 (for DICOM query/retrieve/send)
 EXPOSE 5678 80
 
-ENV DB_TYPE "dbase"
+ENV DB_TYPE="postgres"
 
 ADD dicom.ini /opt/conquest/dicom.ini.template
 ADD entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -103,7 +103,7 @@ echo "========================="
 cat $DICOM_INI
 echo "========================="
 
-rm -r $CONQUEST_HOME/linux
+rm -rf $CONQUEST_HOME/linux
 
 # Regenerate the database
 cd $CONQUEST_HOME


### PR DESCRIPTION
- docker-compose.yml incorrectly ignored
- defaulting to postgres as dbase will never be used anyways
- added -f param to rm as re-running image fails as folder is already deleted and without -f throws fatal